### PR TITLE
1.2.1: Static library building in the Makefile

### DIFF
--- a/include/common/RabbitizerVersion.h
+++ b/include/common/RabbitizerVersion.h
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: © 2022 Decompollaborate */
+/* SPDX-License-Identifier: MIT */
+
+#ifndef RABBITIZER_VERSION_H
+#define RABBITIZER_VERSION_H
+
+#include "Utils.h"
+
+// Header version
+#define RAB_VERSION_MAJOR 1
+#define RAB_VERSION_MINOR 2
+#define RAB_VERSION_PATCH 1
+
+#define RAB_VERSION_STR RAB_STRINGIFY(RAB_VERSION_MAJOR) "." RAB_STRINGIFY(RAB_VERSION_MINOR) "." RAB_STRINGIFY(RAB_VERSION_PATCH)
+
+// Compiled library version
+extern const int RabVersion_Major;
+extern const int RabVersion_Minor;
+extern const int RabVersion_Patch;
+
+extern const char RabVersion_Str[];
+
+#endif

--- a/include/common/Utils.h
+++ b/include/common/Utils.h
@@ -46,6 +46,8 @@
 
 #define ARRAY_COUNT(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+#define RAB_STRINGIFY(x) #x
+
 #define MASK(v, w) ((v) & ((1 << (w)) - 1))
 
 /*

--- a/include/rabbitizer.h
+++ b/include/rabbitizer.h
@@ -1,7 +1,11 @@
+/* SPDX-FileCopyrightText: © 2022 Decompollaborate */
+/* SPDX-License-Identifier: MIT */
+
 #ifndef RABBITIZER_H
 #define RABBITIZER_H
 
 #include "common/Utils.h"
+#include "common/RabbitizerVersion.h"
 #include "common/RabbitizerConfig.h"
 
 #include "instructions/RabbitizerOperandType.h"

--- a/include/rabbitizer.h
+++ b/include/rabbitizer.h
@@ -1,0 +1,20 @@
+#ifndef RABBITIZER_H
+#define RABBITIZER_H
+
+#include "common/Utils.h"
+#include "common/RabbitizerConfig.h"
+
+#include "instructions/RabbitizerOperandType.h"
+#include "instructions/RabbitizerInstrId.h"
+#include "instructions/RabbitizerInstrSuffix.h"
+#include "instructions/RabbitizerInstrDescriptor.h"
+#include "instructions/RabbitizerRegister.h"
+#include "instructions/RabbitizerInstruction.h"
+#include "instructions/RabbitizerInstructionRsp.h"
+#include "instructions/RabbitizerInstructionR5900.h"
+
+#include "analysis/RabbitizerTrackedRegisterState.h"
+#include "analysis/RabbitizerLoPairingInfo.h"
+#include "analysis/RabbitizerRegistersTracker.h"
+
+#endif

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@
 
 [metadata]
 name = rabbitizer
+# Version should be synced with include/common/RabbitizerVersion.h
 version = 1.2.1
 author = Decompollaborate
 license = MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = rabbitizer
-version = 1.2.0
+version = 1.2.1
 author = Decompollaborate
 license = MIT
 description = MIPS instruction decoder

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
             "src/instructions/RabbitizerInstructionR5900/RabbitizerInstructionR5900.c", "src/instructions/RabbitizerInstructionR5900/RabbitizerInstructionR5900_ProcessUniqueId.c",
             "src/instructions/RabbitizerInstrDescriptor.c", "src/instructions/RabbitizerInstrId.c", "src/instructions/RabbitizerRegister.c", "src/instructions/RabbitizerInstrSuffix.c",
             "src/analysis/RabbitizerTrackedRegisterState.c", "src/analysis/RabbitizerRegistersTracker.c", "src/analysis/RabbitizerLoPairingInfo.c",
-            "src/common/Utils.c", "src/common/RabbitizerConfig.c"],
+            "src/common/Utils.c", "src/common/RabbitizerVersion.c", "src/common/RabbitizerConfig.c"],
             include_dirs=["include", "rabbitizer"],
             extra_compile_args = [
                 "-std=c11",

--- a/src/common/RabbitizerVersion.c
+++ b/src/common/RabbitizerVersion.c
@@ -1,0 +1,10 @@
+/* SPDX-FileCopyrightText: © 2022 Decompollaborate */
+/* SPDX-License-Identifier: MIT */
+
+#include "common/RabbitizerVersion.h"
+
+const int RabVersion_Major = RAB_VERSION_MAJOR;
+const int RabVersion_Minor = RAB_VERSION_MINOR;
+const int RabVersion_Patch = RAB_VERSION_PATCH;
+
+const char RabVersion_Str[] = RAB_VERSION_STR;


### PR DESCRIPTION
- Makefile now creates a `librabbitizer.a` file by default.
- Makefile can also build a `librabbitizer.so` with `make dynamic`
- New `include/rabbitizer.h` header which includes every other header
- Added a version header