### PR TITLE
Don't attempt disassembling vclipw / vsqrt in gnu mode

### DIFF
--- a/include/generated/InstrDescriptor_Descriptors_array.h
+++ b/include/generated/InstrDescriptor_Descriptors_array.h
@@ -677,7 +677,7 @@ const RabbitizerInstrDescriptor RabbitizerInstrDescriptor_Descriptors[] = {
     [RABBITIZER_INSTR_ID_r5900_vmulaq] = { .operands={RAB_OPERAND_r5900_ACCxyzw, RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_Q}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw },
     [RABBITIZER_INSTR_ID_r5900_vabs] = { .operands={RAB_OPERAND_r5900_vftxyzw, RAB_OPERAND_r5900_vfsxyzw}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw, .isFloat=true },
     [RABBITIZER_INSTR_ID_r5900_vmulai] = { .operands={RAB_OPERAND_r5900_ACCxyzw, RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_I}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw },
-    [RABBITIZER_INSTR_ID_r5900_vclipw] = { .operands={RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_vftn}, .isFloat=true },
+    [RABBITIZER_INSTR_ID_r5900_vclipw] = { .operands={RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_vftn}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw, .isFloat=true },
     [RABBITIZER_INSTR_ID_r5900_vaddaq] = { .operands={RAB_OPERAND_r5900_ACCxyzw, RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_Q}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw, .isFloat=true },
     [RABBITIZER_INSTR_ID_r5900_vmaddaq] = { .operands={RAB_OPERAND_r5900_ACCxyzw, RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_Q}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw, .isFloat=true },
     [RABBITIZER_INSTR_ID_r5900_vaddai] = { .operands={RAB_OPERAND_r5900_ACCxyzw, RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_I}, .instrSuffix=RABINSTRSUFFIX_R5900_xyzw, .isFloat=true },

--- a/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
+++ b/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
@@ -127,10 +127,12 @@ bool RabbitizerInstruction_mustDisasmAsData(const RabbitizerInstruction *self) {
                 }
                 break;
             case RABBITIZER_INSTR_ID_r5900_vclipw:
-                // The vclipw instruction has variants that are undocumented (vclipw.xy, vclipw.z) and don't assemble in gnu as
+                // The vclipw instruction has variants that are undocumented (vclipw.xy, vclipw.z) and don't assemble in
+                // gnu as
                 return true;
             case RABBITIZER_INSTR_ID_r5900_vsqrt:
-                // The vclipw instruction seems to be representable in multiple ways, and we only disassemble one of them
+                // The vclipw instruction seems to be representable in multiple ways, and we only disassemble one of
+                // them
                 return true;
 
             default:

--- a/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
+++ b/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
@@ -127,8 +127,10 @@ bool RabbitizerInstruction_mustDisasmAsData(const RabbitizerInstruction *self) {
                 }
                 break;
             case RABBITIZER_INSTR_ID_r5900_vclipw:
+                // The vclipw instruction has variants that are undocumented (vclipw.xy, vclipw.z) and don't assemble in gnu as
                 return true;
             case RABBITIZER_INSTR_ID_r5900_vsqrt:
+                // The vclipw instruction seems to be representable in multiple ways, and we only disassemble one of them
                 return true;
 
             default:

--- a/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
+++ b/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
@@ -128,6 +128,8 @@ bool RabbitizerInstruction_mustDisasmAsData(const RabbitizerInstruction *self) {
                 break;
             case RABBITIZER_INSTR_ID_r5900_vclipw:
                 return true;
+            case RABBITIZER_INSTR_ID_r5900_vsqrt:
+                return true;
 
             default:
                 break;

--- a/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
+++ b/src/instructions/RabbitizerInstruction/RabbitizerInstruction_Disassemble.c
@@ -126,6 +126,8 @@ bool RabbitizerInstruction_mustDisasmAsData(const RabbitizerInstruction *self) {
                     return true;
                 }
                 break;
+            case RABBITIZER_INSTR_ID_r5900_vclipw:
+                return true;
 
             default:
                 break;

--- a/tables/tables/instr_id/r5900/r5900_cop2_special2.inc
+++ b/tables/tables/instr_id/r5900/r5900_cop2_special2.inc
@@ -216,6 +216,7 @@ Note: opcode is flo | (
     RABBITIZER_DEF_INSTR_ID(
         r5900, 0x1F, vclipw,
         .operands={RAB_OPERAND_r5900_vfsxyzw, RAB_OPERAND_r5900_vftn},
+        .instrSuffix=RABINSTRSUFFIX_R5900_xyzw,
         .isFloat=true
     ) // Clip
 


### PR DESCRIPTION
These can (dis)assemble slightly differently and the documentation is shoddy, so for now just make them .word in gnu mode