### PR TITLE
Fix heap corruption in Rust bindings

### DIFF
--- a/rust/src/instruction.rs
+++ b/rust/src/instruction.rs
@@ -709,7 +709,7 @@ impl Instruction {
             let buffer_size =
                 RabbitizerInstruction_getSizeForBuffer(self, imm_override_len, extra_l_just);
 
-            let mut buffer: Vec<u8> = vec![0; buffer_size];
+            let mut buffer: Vec<u8> = vec![0; buffer_size + 1];
             let disassembled_size = RabbitizerInstruction_disassemble(
                 self,
                 buffer.as_mut_ptr() as *mut core::ffi::c_char,

--- a/rust/src/opereand_type.rs
+++ b/rust/src/opereand_type.rs
@@ -30,7 +30,7 @@ impl operand_type_enum::OperandType {
         unsafe {
             let buffer_size = RabbitizerOperandType_getBufferSize(*self, instr, imm_override_len);
 
-            let mut buffer: Vec<u8> = vec![0; buffer_size];
+            let mut buffer: Vec<u8> = vec![0; buffer_size + 1];
             let disassembled_size = RabbitizerOperandType_disassemble(
                 *self,
                 instr,


### PR DESCRIPTION
`RabbitizerInstruction_getSizeForBuffer` and `RabbitizerOperandType_getBufferSize` return the size **without** the null terminator, so we need to allocate one more byte to avoid writing past the allocated vector bounds.

This matches the behavior of the C code in the various places these functions are used.