### PR TITLE
Add support for Python abi3

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -1,5 +1,5 @@
 # Based on https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
-# Permalink: https://github.com/pypa/cibuildwheel/blob/9c00cb4f6b517705a3794b22395aedc36257242c/examples/github-deploy.yml
+# Permalink: https://github.com/pypa/cibuildwheel/blob/bb153041f0defc85849ef2d519c39c9218d889d0/examples/github-deploy.yml
 
 name: Build and upload to PyPI
 
@@ -16,6 +16,7 @@ jobs:
     name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: linux-intel
@@ -33,24 +34,29 @@ jobs:
             # macos-14+ (including latest) are ARM64 runners
             runs-on: macos-latest
           - os: android-intel
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-22.04
             platform: android
           - os: android-arm
             # GitHub Actions doesn’t currently support the Android emulator on any ARM
             # runner. So we build on a non-ARM runner, which will skip the tests.
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-22.04
             platform: android
             archs: arm64_v8a
           - os: ios
             runs-on: macos-latest
             platform: ios
+          - os: pyodide
+            runs-on: ubuntu-22.04
+            platform: pyodide
 
     steps:
       - name: Checkout reposistory
         uses: actions/checkout@main
+        with:
+          persist-credentials: false
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
@@ -67,6 +73,8 @@ jobs:
     steps:
       - name: Checkout reposistory
         uses: actions/checkout@main
+        with:
+          persist-credentials: false
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Python's limited API (a.k.a. `abi3`).
+  - This allows us to build a single wheel that can work in multiple Python
+    versions, instead of needing to build a wheel for each Python version.
+  - The minimum Python version for `abi3` compatibility is 3.4 now.
+
 ## [1.14.3] - 2025-10-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.14.3"
 description = "MIPS instruction decoder"
 # license = "MIT"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.4"
 authors = [
     { name="Anghelo Carvajal", email="angheloalf95@gmail.com" },
 ]

--- a/rabbitizer/enums/enums_utils.c
+++ b/rabbitizer/enums/enums_utils.c
@@ -13,7 +13,7 @@ int rabbitizer_EnumMetadata_Initialize(PyObject *submodule, RabbitizerEnumMetada
             goto error;
         }
 
-        enumValues[i].instance = PyObject_CallObject((PyObject*)&rabbitizer_type_Enum_TypeObject, args);
+        enumValues[i].instance = PyObject_CallObject(rabbitizer_type_Enum_TypeObject, args);
         Py_DECREF(args);
         if (enumValues[i].instance == NULL) {
             goto error;

--- a/rabbitizer/enums/enums_utils.h
+++ b/rabbitizer/enums/enums_utils.h
@@ -7,13 +7,15 @@
 
 
 #define PY_SSIZE_T_CLEAN
+#define Py_LIMITED_API 0x03040000
 #include <Python.h>
 #include "structmember.h"
 
 #include <stdbool.h>
 
 
-extern PyTypeObject rabbitizer_type_Enum_TypeObject;
+extern PyType_Spec rabbitizer_type_Enum_Spec;
+extern PyObject *rabbitizer_type_Enum_TypeObject;
 
 
 typedef struct PyRabbitizerEnum {
@@ -51,7 +53,7 @@ int rabbitizer_EnumMetadata_Initialize(PyObject *submodule, RabbitizerEnumMetada
     }; \
     PyObject *rabbitizer_enum_##enumName##_Init(void) { \
         PyObject *submodule; \
-        if (PyType_Ready(&rabbitizer_type_Enum_TypeObject) < 0) { \
+        if (PyType_Ready((PyTypeObject *)rabbitizer_type_Enum_TypeObject) < 0) { \
             return NULL; \
         } \
         submodule = PyModule_Create(&rabbitizer_enum_##enumName##_module); \
@@ -66,7 +68,7 @@ int rabbitizer_EnumMetadata_Initialize(PyObject *submodule, RabbitizerEnumMetada
     } \
     /* Return true if o is of this enum type */ \
     int rabbitizer_enum_##enumName##_Check(PyObject *o) { \
-        int isInstance = PyObject_IsInstance(o, (PyObject*)&rabbitizer_type_Enum_TypeObject); \
+        int isInstance = PyObject_IsInstance(o, rabbitizer_type_Enum_TypeObject); \
         int enumTypeCmp; \
         if (isInstance < 0) { \
             /* An error happened */ \

--- a/rabbitizer/enums/enums_utils.h
+++ b/rabbitizer/enums/enums_utils.h
@@ -7,7 +7,6 @@
 
 
 #define PY_SSIZE_T_CLEAN
-#define Py_LIMITED_API 0x03040000
 #include <Python.h>
 #include "structmember.h"
 

--- a/rabbitizer/enums/rabbitizer_type_Enum.c
+++ b/rabbitizer/enums/rabbitizer_type_Enum.c
@@ -9,11 +9,17 @@
 static void rabbitizer_type_Enum_dealloc(PyRabbitizerEnum *self) {
     Py_XDECREF(self->enumType);
     Py_XDECREF(self->name);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+
+    freefunc tp_free = PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+    tp_free((PyObject *) self);
 }
 
 static PyObject *rabbitizer_type_Enum_new(PyTypeObject *type, UNUSED PyObject *args, UNUSED PyObject *kwds) {
-    PyRabbitizerEnum *self = (PyRabbitizerEnum *) type->tp_alloc(type, 0);
+    allocfunc tp_alloc = PyType_GetSlot(type, Py_tp_alloc);
+    if (tp_alloc == NULL) {
+        return NULL;
+    }
+    PyRabbitizerEnum *self = (void *) tp_alloc(type, 0);
 
     if (self == NULL) {
         return NULL;
@@ -110,7 +116,7 @@ Py_hash_t rabbitizer_type_Enum_hash(PyRabbitizerEnum *self) {
 
 // Checks for the 6 basic comparisons (==, !=, <, <=, >, >=)
 PyObject *rabbitizer_type_Enum_richcompare(PyRabbitizerEnum *self, PyObject *other, int op) {
-    int isInstance = PyObject_IsInstance(other, (PyObject*)&rabbitizer_type_Enum_TypeObject);
+    int isInstance = PyObject_IsInstance(other, rabbitizer_type_Enum_TypeObject);
     int enumTypeCmp;
     int otherValue;
 
@@ -173,7 +179,7 @@ static PyObject *rabbitizer_type_Enum___reduce__(PyRabbitizerEnum *self, UNUSED 
 
     args = PyTuple_Pack(3, enumType, name, value);
 
-    return PyTuple_Pack(2, (PyObject*)&rabbitizer_type_Enum_TypeObject, args);
+    return PyTuple_Pack(2, rabbitizer_type_Enum_TypeObject, args);
 }
 
 
@@ -197,21 +203,27 @@ static PyObject *rabbitizer_type_Enum_str(PyRabbitizerEnum *self) {
 
 // TODO: implement hash and int
 
-PyTypeObject rabbitizer_type_Enum_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.Enum",
-    .tp_doc = PyDoc_STR("Enum"),
-    .tp_basicsize = sizeof(PyRabbitizerEnum),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = rabbitizer_type_Enum_new,
-    .tp_init = (initproc) rabbitizer_type_Enum_init,
-    .tp_dealloc = (destructor) rabbitizer_type_Enum_dealloc,
-    .tp_hash = (hashfunc) rabbitizer_type_Enum_hash,
-    .tp_richcompare = (richcmpfunc) rabbitizer_type_Enum_richcompare,
-    .tp_repr = (reprfunc) rabbitizer_type_Enum_repr,
-    .tp_str = (reprfunc) rabbitizer_type_Enum_str,
-    //.tp_members = rabbitizer_type_Enum_members,
-    .tp_methods = rabbitizer_type_Enum_methods,
-    .tp_getset = rabbitizer_type_Enum_getsetters,
+PyObject *rabbitizer_type_Enum_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_type_Enum_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("Enum")},
+    {Py_tp_new, rabbitizer_type_Enum_new},
+    {Py_tp_init, rabbitizer_type_Enum_init},
+    {Py_tp_dealloc, rabbitizer_type_Enum_dealloc},
+    {Py_tp_hash, rabbitizer_type_Enum_hash},
+    {Py_tp_richcompare, rabbitizer_type_Enum_richcompare},
+    {Py_tp_repr, rabbitizer_type_Enum_repr},
+    {Py_tp_str, rabbitizer_type_Enum_str},
+    // {Py_tp_members, rabbitizer_type_Enum_members},
+    {Py_tp_methods, rabbitizer_type_Enum_methods},
+    {Py_tp_getset, rabbitizer_type_Enum_getsetters},
+    {0, NULL}
+};
+
+PyType_Spec rabbitizer_type_Enum_Spec = {
+    .name = "rabbitizer.Enum",
+    .basicsize = sizeof(PyRabbitizerEnum),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = rabbitizer_type_Enum_Slots,
 };

--- a/rabbitizer/rabbitizer_global_config.c
+++ b/rabbitizer/rabbitizer_global_config.c
@@ -161,13 +161,19 @@ static PyGetSetDef rabbitizer_global_config_GetSets[] = {
     { 0 },
 };
 
-PyTypeObject rabbitizer_global_config_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.config",
-    .tp_doc = PyDoc_STR(""),
-    .tp_basicsize = sizeof(PyObject),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
-    .tp_new = PyType_GenericNew,
-    .tp_getset = rabbitizer_global_config_GetSets,
+PyObject *rabbitizer_global_config_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_global_config_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("")},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_getset, rabbitizer_global_config_GetSets},
+    {0, NULL},
+};
+
+PyType_Spec rabbitizer_global_config_Spec = {
+    .name = "rabbitizer.config",
+    .basicsize = sizeof(PyObject),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = rabbitizer_global_config_Slots,
 };

--- a/rabbitizer/rabbitizer_macro_utilities.h
+++ b/rabbitizer/rabbitizer_macro_utilities.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #define PY_SSIZE_T_CLEAN
-#define Py_LIMITED_API 0x03040000
 #include <Python.h>
 #include <structmember.h>
 

--- a/rabbitizer/rabbitizer_macro_utilities.h
+++ b/rabbitizer/rabbitizer_macro_utilities.h
@@ -6,8 +6,9 @@
 #pragma once
 
 #define PY_SSIZE_T_CLEAN
+#define Py_LIMITED_API 0x03040000
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 
 #define RAB_STRCMP_LITERAL(var, literal) strncmp(var, literal, sizeof(literal) - 1)
@@ -19,7 +20,8 @@
         Rabbitizer##typeName memberName; \
     } PyRabbitizer##typeName; \
     \
-    extern PyTypeObject rabbitizer_type_##typeName##_TypeObject; \
+    extern PyObject *rabbitizer_type_##typeName##_TypeObject; \
+    extern PyType_Spec rabbitizer_type_##typeName##_Spec; \
     \
     int rabbitizer_type_##typeName##_TypeObject_Check(PyObject *object); \
     int rabbitizer_type_##typeName##_Converter_Optional(PyObject *object, PyRabbitizer##typeName **address);
@@ -27,7 +29,7 @@
 #define DEF_RAB_TYPE(typeName) \
     /* Returns positive if the argument is an instance, 0 if it isn't or negative on error */ \
     int rabbitizer_type_##typeName##_TypeObject_Check(PyObject *object) { \
-        int isInstance = PyObject_IsInstance(object, (PyObject*)&rabbitizer_type_##typeName##_TypeObject); \
+        int isInstance = PyObject_IsInstance(object, rabbitizer_type_##typeName##_TypeObject); \
         \
         if (isInstance < 0) { \
             /* An error happened */ \
@@ -65,9 +67,27 @@
             return 1; /* successful */ \
         } \
         \
-        PyErr_Format(PyExc_TypeError, "argument must be %s or None, not %s", rabbitizer_type_##typeName##_TypeObject.tp_name, object->ob_type->tp_name); \
+        PyErr_Format(PyExc_TypeError, "argument must be %s or None, not %s", get_tp_name(rabbitizer_type_##typeName##_TypeObject), get_tp_name(object)); \
         return 0; /* fail */ \
     }
 
+static inline const char *get_tp_name(PyObject *object) {
+    PyObject *type = (PyObject *)Py_TYPE(object);
+
+    PyObject *name = PyObject_GetAttrString(type, "__name__");
+    if (name == NULL) {
+        return NULL;
+    }
+
+    PyObject *bytes = PyUnicode_AsEncodedString(name, "utf-8", "strict");
+    Py_DECREF(name);
+    if (bytes == NULL) {
+        return NULL;
+    }
+
+    const char *result = PyBytes_AsString(bytes);
+    Py_DECREF(bytes);
+    return result;
+}
 
 #endif

--- a/rabbitizer/rabbitizer_module.c
+++ b/rabbitizer/rabbitizer_module.c
@@ -18,20 +18,21 @@ typedef enum ModuleAttributeCategory {
 
 typedef struct ModuleAttribute {
     union {
-        PyTypeObject *type;
+        PyObject **type;
         PyObject *(*init)(void);
-        PyTypeObject *global;
+        PyObject **global;
     };
     ModuleAttributeCategory cat;
+    PyType_Spec *spec;
     const char *name;
     bool isInstanced;
     PyObject *instance;
 } ModuleAttributes;
 
-#define MODULE_ATTRIBUTE_TYPE(name)   { {.type   = &rabbitizer_type_##name##_TypeObject},   MODULE_ATTRIBUTE_CAT_TYPE,   #name, false, NULL }
-#define MODULE_ATTRIBUTE_INIT(name)   { {.init   = rabbitizer_submodule_##name##_Init},     MODULE_ATTRIBUTE_CAT_INIT,   #name, false, NULL }
-#define MODULE_ATTRIBUTE_ENUM(name)   { {.init   = rabbitizer_enum_##name##_Init},          MODULE_ATTRIBUTE_CAT_INIT,   #name, false, NULL }
-#define MODULE_ATTRIBUTE_GLOBAL(name) { {.global = &rabbitizer_global_##name##_TypeObject}, MODULE_ATTRIBUTE_CAT_GLOBAL, #name, false, NULL }
+#define MODULE_ATTRIBUTE_TYPE(name)   { {.type   = &rabbitizer_type_##name##_TypeObject},   MODULE_ATTRIBUTE_CAT_TYPE,   &rabbitizer_type_##name##_Spec,   #name, false, NULL }
+#define MODULE_ATTRIBUTE_INIT(name)   { {.init   = rabbitizer_submodule_##name##_Init},     MODULE_ATTRIBUTE_CAT_INIT,   NULL,                             #name, false, NULL }
+#define MODULE_ATTRIBUTE_ENUM(name)   { {.init   = rabbitizer_enum_##name##_Init},          MODULE_ATTRIBUTE_CAT_INIT,   NULL,                             #name, false, NULL }
+#define MODULE_ATTRIBUTE_GLOBAL(name) { {.global = &rabbitizer_global_##name##_TypeObject}, MODULE_ATTRIBUTE_CAT_GLOBAL, &rabbitizer_global_##name##_Spec, #name, false, NULL }
 
 static ModuleAttributes rabbitizer_module_attributes[] = {
     MODULE_ATTRIBUTE_INIT(Utils),
@@ -62,6 +63,14 @@ static ModuleAttributes rabbitizer_module_attributes[] = {
 };
 
 static int rabbitizer_module_attributes_Ready(void) {
+    rabbitizer_type_Enum_TypeObject = PyType_FromSpec(&rabbitizer_type_Enum_Spec);
+    if (rabbitizer_type_Enum_TypeObject == NULL) {
+        return -1;
+    }
+    if (PyType_Ready((PyTypeObject*)rabbitizer_type_Enum_TypeObject) < 0) {
+        return -1;
+    }
+
     // Sanity checks and PyType_Ready
     for (size_t i = 0; i < ARRAY_COUNT(rabbitizer_module_attributes); i++) {
         if (rabbitizer_module_attributes[i].global == NULL || rabbitizer_module_attributes[i].name == NULL) {
@@ -70,7 +79,11 @@ static int rabbitizer_module_attributes_Ready(void) {
         switch (rabbitizer_module_attributes[i].cat) {
             case MODULE_ATTRIBUTE_CAT_TYPE:
             case MODULE_ATTRIBUTE_CAT_GLOBAL:
-                if (PyType_Ready(rabbitizer_module_attributes[i].type) < 0) {
+                *rabbitizer_module_attributes[i].type = PyType_FromSpec(rabbitizer_module_attributes[i].spec);
+                if (*rabbitizer_module_attributes[i].type == NULL) {
+                    return -1;
+                }
+                if (PyType_Ready((PyTypeObject*)*rabbitizer_module_attributes[i].type) < 0) {
                     return -1;
                 }
                 break;
@@ -90,7 +103,7 @@ static int rabbitizer_module_attributes_Initialize(PyObject *module) {
     for (size_t i = 0; i < ARRAY_COUNT(rabbitizer_module_attributes); i++) {
         switch (rabbitizer_module_attributes[i].cat) {
             case MODULE_ATTRIBUTE_CAT_TYPE:
-                rabbitizer_module_attributes[i].instance = (PyObject*) rabbitizer_module_attributes[i].type;
+                rabbitizer_module_attributes[i].instance = *rabbitizer_module_attributes[i].type;
                 Py_INCREF(rabbitizer_module_attributes[i].instance);
                 break;
 
@@ -102,7 +115,7 @@ static int rabbitizer_module_attributes_Initialize(PyObject *module) {
                 break;
 
             case MODULE_ATTRIBUTE_CAT_GLOBAL:
-                rabbitizer_module_attributes[i].instance = PyObject_CallObject((PyObject*)rabbitizer_module_attributes[i].global, NULL);
+                rabbitizer_module_attributes[i].instance = PyObject_CallObject(*rabbitizer_module_attributes[i].global, NULL);
                 if (rabbitizer_module_attributes[i].instance == NULL) {
                     goto error;
                 }

--- a/rabbitizer/rabbitizer_module.h
+++ b/rabbitizer/rabbitizer_module.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #define PY_SSIZE_T_CLEAN
+#define Py_LIMITED_API 0x03040000
 #include <Python.h>
 #include "structmember.h"
 
@@ -25,9 +26,10 @@ extern PyModuleDef rabbitizer_module;
 
 PyObject *rabbitizer_submodule_Utils_Init(void);
 
-extern PyTypeObject rabbitizer_global_config_TypeObject;
+extern PyObject *rabbitizer_global_config_TypeObject;
+extern PyType_Spec rabbitizer_global_config_Spec;
 
-extern PyTypeObject rabbitizer_type_Enum_TypeObject;
+extern PyObject *rabbitizer_type_Enum_TypeObject;
 
 DECL_RAB_TYPE(Instruction, instr)
 DECL_RAB_TYPE(LoPairingInfo, pairingInfo)

--- a/rabbitizer/rabbitizer_module.h
+++ b/rabbitizer/rabbitizer_module.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #define PY_SSIZE_T_CLEAN
-#define Py_LIMITED_API 0x03040000
 #include <Python.h>
 #include "structmember.h"
 

--- a/rabbitizer/rabbitizer_type_Instruction.c
+++ b/rabbitizer/rabbitizer_type_Instruction.c
@@ -12,7 +12,9 @@
 
 static void rabbitizer_type_Instruction_dealloc(PyRabbitizerInstruction *self) {
     RabbitizerInstruction_destroy(&self->instr);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+
+    freefunc tp_free = PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+    tp_free((PyObject *) self);
 }
 
 static int rabbitizer_type_Instruction_init(PyRabbitizerInstruction *self, PyObject *args, PyObject *kwds) {
@@ -23,7 +25,7 @@ static int rabbitizer_type_Instruction_init(PyRabbitizerInstruction *self, PyObj
     int enumCheck;
     RabbitizerInstrCategory instrCategory = RABBITIZER_INSTRCAT_CPU;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "I|IO!", kwlist, &word, &vram, &rabbitizer_type_Enum_TypeObject, &category)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "I|IO!", kwlist, &word, &vram, rabbitizer_type_Enum_TypeObject, &category)) {
         return -1;
     }
 
@@ -409,7 +411,7 @@ static PyObject *rabbitizer_type_Instruction_sameOpcode(PyRabbitizerInstruction 
     static char *kwlist[] = { "other", NULL };
     PyRabbitizerInstruction *other;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &other)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &other)) {
         return NULL;
     }
 
@@ -423,7 +425,7 @@ static PyObject *rabbitizer_type_Instruction_sameOpcodeButDifferentArguments(PyR
     static char *kwlist[] = { "other", NULL };
     PyRabbitizerInstruction *other;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &other)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &other)) {
         return NULL;
     }
 
@@ -439,7 +441,7 @@ static PyObject *rabbitizer_type_Instruction_hasOperand(PyRabbitizerInstruction 
     int enumCheck;
     RabbitizerOperandType operandType = RAB_OPERAND_ALL_INVALID;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Enum_TypeObject, &pyOperand)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Enum_TypeObject, &pyOperand)) {
         return NULL;
     }
 
@@ -471,7 +473,7 @@ static PyObject *rabbitizer_type_Instruction_hasOperandAlias(PyRabbitizerInstruc
     int enumCheck;
     RabbitizerOperandType operandType = RAB_OPERAND_ALL_INVALID;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Enum_TypeObject, &pyOperand)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Enum_TypeObject, &pyOperand)) {
         return NULL;
     }
 
@@ -624,7 +626,7 @@ static PyObject *rabbitizer_type_Instruction___reduce__(PyRabbitizerInstruction 
 
     args = PyTuple_Pack(3, word, vram, category);
 
-    return PyTuple_Pack(2, (PyObject*)&rabbitizer_type_Instruction_TypeObject, args);
+    return PyTuple_Pack(2, rabbitizer_type_Instruction_TypeObject, args);
 }
 
 
@@ -779,20 +781,25 @@ static PyObject *rabbitizer_type_Instruction_str(PyRabbitizerInstruction *self) 
 DEF_RAB_TYPE(Instruction)
 
 
-PyTypeObject rabbitizer_type_Instruction_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.Instruction",
-    .tp_doc = PyDoc_STR("Instruction"),
-    .tp_basicsize = sizeof(PyRabbitizerInstruction),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = PyType_GenericNew,
-    .tp_init = (initproc) rabbitizer_type_Instruction_init,
-    .tp_dealloc = (destructor) rabbitizer_type_Instruction_dealloc,
-    .tp_repr = (reprfunc) rabbitizer_type_Instruction_repr,
-    .tp_str = (reprfunc) rabbitizer_type_Instruction_str,
-    .tp_members = rabbitizer_type_Instruction_members,
-    .tp_methods = rabbitizer_type_Instruction_methods,
-    .tp_getset = rabbitizer_type_Instruction_getsetters,
+PyObject *rabbitizer_type_Instruction_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_type_Instruction_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("Instruction")},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_init, rabbitizer_type_Instruction_init},
+    {Py_tp_dealloc, rabbitizer_type_Instruction_dealloc},
+    {Py_tp_repr, rabbitizer_type_Instruction_repr},
+    {Py_tp_str, rabbitizer_type_Instruction_str},
+    {Py_tp_members, rabbitizer_type_Instruction_members},
+    {Py_tp_methods, rabbitizer_type_Instruction_methods},
+    {Py_tp_getset, rabbitizer_type_Instruction_getsetters},
+    {0, NULL},
 };
 
+PyType_Spec rabbitizer_type_Instruction_Spec = {
+    .name = "rabbitizer.Instruction",
+    .basicsize = sizeof(PyRabbitizerInstruction),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = rabbitizer_type_Instruction_Slots,
+};

--- a/rabbitizer/rabbitizer_type_JrRegData.c
+++ b/rabbitizer/rabbitizer_type_JrRegData.c
@@ -5,7 +5,9 @@
 
 
 static void rabbitizer_type_JrRegData_dealloc(PyRabbitizerJrRegData *self) {
-    Py_TYPE(self)->tp_free((PyObject *) self);
+
+    freefunc tp_free = PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+    tp_free((PyObject *) self);
 }
 
 static int rabbitizer_type_JrRegData_init(PyRabbitizerJrRegData *self, UNUSED PyObject *args, UNUSED PyObject *kwds) {
@@ -60,19 +62,25 @@ static PyMethodDef rabbitizer_type_JrRegData_methods[] = {
 DEF_RAB_TYPE(JrRegData)
 
 
-PyTypeObject rabbitizer_type_JrRegData_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.JrRegData",
-    .tp_doc = PyDoc_STR("JrRegData"),
-    .tp_basicsize = sizeof(PyRabbitizerJrRegData),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = PyType_GenericNew,
-    .tp_init = (initproc) rabbitizer_type_JrRegData_init,
-    .tp_dealloc = (destructor) rabbitizer_type_JrRegData_dealloc,
-    // .tp_repr = (reprfunc) rabbitizer_type_JrRegData_repr,
-    // .tp_as_sequence = &rabbitizer_type_JrRegData_classSeqMethods,
-    // .tp_str = (reprfunc) rabbitizer_type_JrRegData_str,
-    .tp_methods = rabbitizer_type_JrRegData_methods,
-    // .tp_getset = rabbitizer_type_JrRegData_getsetters,
+PyObject *rabbitizer_type_JrRegData_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_type_JrRegData_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("JrRegData")},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_init, rabbitizer_type_JrRegData_init},
+    {Py_tp_dealloc, rabbitizer_type_JrRegData_dealloc},
+    // {Py_tp_repr, rabbitizer_type_JrRegData_repr},
+    // {Py_tp_as_sequence, &rabbitizer_type_JrRegData_classSeqMethods},
+    // {Py_tp_str, rabbitizer_type_JrRegData_str},
+    {Py_tp_methods, rabbitizer_type_JrRegData_methods},
+    // {Py_tp_getset, rabbitizer_type_JrRegData_getsetters},
+    {0, NULL},
+};
+
+PyType_Spec rabbitizer_type_JrRegData_Spec = {
+    .name = "rabbitizer.JrRegData",
+    .basicsize = sizeof(PyRabbitizerJrRegData),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = rabbitizer_type_JrRegData_Slots,
 };

--- a/rabbitizer/rabbitizer_type_LoPairingInfo.c
+++ b/rabbitizer/rabbitizer_type_LoPairingInfo.c
@@ -5,7 +5,9 @@
 
 
 static void rabbitizer_type_LoPairingInfo_dealloc(PyRabbitizerLoPairingInfo *self) {
-    Py_TYPE(self)->tp_free((PyObject *) self);
+
+    freefunc tp_free = PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+    tp_free((PyObject *) self);
 }
 
 static int rabbitizer_type_LoPairingInfo_init(PyRabbitizerLoPairingInfo *self, PyObject *args, PyObject *kwds) {
@@ -59,19 +61,25 @@ static PyGetSetDef rabbitizer_type_LoPairingInfo_getsetters[] = {
 DEF_RAB_TYPE(LoPairingInfo)
 
 
-PyTypeObject rabbitizer_type_LoPairingInfo_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.LoPairingInfo",
-    .tp_doc = PyDoc_STR("LoPairingInfo"),
-    .tp_basicsize = sizeof(PyRabbitizerLoPairingInfo),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = PyType_GenericNew,
-    .tp_init = (initproc) rabbitizer_type_LoPairingInfo_init,
-    .tp_dealloc = (destructor) rabbitizer_type_LoPairingInfo_dealloc,
-    // .tp_repr = (reprfunc) rabbitizer_type_LoPairingInfo_repr,
-    // .tp_str = (reprfunc) rabbitizer_type_LoPairingInfo_str,
-    .tp_members = rabbitizer_type_LoPairingInfo_members,
-    // .tp_methods = rabbitizer_type_Instr_methods,
-    .tp_getset = rabbitizer_type_LoPairingInfo_getsetters,
+PyObject *rabbitizer_type_LoPairingInfo_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_type_LoPairingInfo_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("LoPairingInfo")},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_init, rabbitizer_type_LoPairingInfo_init},
+    {Py_tp_dealloc, rabbitizer_type_LoPairingInfo_dealloc},
+    // {Py_tp_repr, rabbitizer_type_LoPairingInfo_repr},
+    // {Py_tp_str, rabbitizer_type_LoPairingInfo_str},
+    {Py_tp_members, rabbitizer_type_LoPairingInfo_members},
+    // {Py_tp_methods, rabbitizer_type_Instr_methods},
+    {Py_tp_getset, rabbitizer_type_LoPairingInfo_getsetters},
+    {0, NULL},
+};
+
+PyType_Spec rabbitizer_type_LoPairingInfo_Spec = {
+    .name = "rabbitizer.LoPairingInfo",
+    .basicsize = sizeof(PyRabbitizerLoPairingInfo),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = rabbitizer_type_LoPairingInfo_Slots,
 };

--- a/rabbitizer/rabbitizer_type_RegistersTracker.c
+++ b/rabbitizer/rabbitizer_type_RegistersTracker.c
@@ -5,7 +5,9 @@
 
 static void rabbitizer_type_RegistersTracker_dealloc(PyRabbitizerRegistersTracker *self) {
     RabbitizerRegistersTracker_destroy(&self->tracker);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+
+    freefunc tp_free = PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+    tp_free((PyObject *) self);
 }
 
 static int rabbitizer_type_RegistersTracker_init(PyRabbitizerRegistersTracker *self, PyObject *args, PyObject *kwds) {
@@ -31,7 +33,7 @@ static PyObject *rabbitizer_type_RegistersTracker_moveRegisters(PyRabbitizerRegi
     static char *kwlist[] = { "instr", NULL };
     PyRabbitizerInstruction *instr;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &instr)) {
         return NULL;
     }
 
@@ -46,7 +48,7 @@ static PyObject *rabbitizer_type_RegistersTracker_overwriteRegisters(PyRabbitize
     PyRabbitizerInstruction *instr;
     int instrOffset;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
         return NULL;
     }
 
@@ -60,7 +62,7 @@ static PyObject *rabbitizer_type_RegistersTracker_unsetRegistersAfterFuncCall(Py
     PyRabbitizerInstruction *instr;
     PyRabbitizerInstruction *prevInstr;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &rabbitizer_type_Instruction_TypeObject, &prevInstr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, rabbitizer_type_Instruction_TypeObject, &prevInstr)) {
         return NULL;
     }
 
@@ -75,7 +77,7 @@ static PyObject *rabbitizer_type_RegistersTracker_getAddressIfCanSetType(PyRabbi
     int instrOffset;
     uint32_t dstAddress = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
         return NULL;
     }
 
@@ -92,7 +94,7 @@ static PyObject *rabbitizer_type_RegistersTracker_getJrInfo(PyRabbitizerRegister
     int dstOffset = 0;
     uint32_t dstAddress = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &instr)) {
         return NULL;
     }
 
@@ -108,11 +110,11 @@ static PyObject *rabbitizer_type_RegistersTracker_getJrRegData(PyRabbitizerRegis
     PyRabbitizerInstruction *instr;
     PyRabbitizerJrRegData *ret;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &instr)) {
         return NULL;
     }
 
-    ret = (PyRabbitizerJrRegData*)PyObject_CallObject((PyObject*)&rabbitizer_type_JrRegData_TypeObject, NULL);
+    ret = (PyRabbitizerJrRegData*)PyObject_CallObject(rabbitizer_type_JrRegData_TypeObject, NULL);
     if (ret == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "Internal error: not able to instance JrRegData object");
         return NULL;
@@ -130,7 +132,7 @@ static PyObject *rabbitizer_type_RegistersTracker_processLui(PyRabbitizerRegiste
     PyRabbitizerInstruction *pyPrevInstr = NULL;
     RabbitizerInstruction *prevInstr = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i|O&", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset, rabbitizer_type_Instruction_Converter_Optional, &pyPrevInstr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i|O&", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset, rabbitizer_type_Instruction_Converter_Optional, &pyPrevInstr)) {
         return NULL;
     }
 
@@ -148,7 +150,7 @@ static PyObject *rabbitizer_type_RegistersTracker_processGpLoad(PyRabbitizerRegi
     PyRabbitizerInstruction *instr;
     int instrOffset;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
         return NULL;
     }
 
@@ -162,7 +164,7 @@ static PyObject *rabbitizer_type_RegistersTracker_getLuiOffsetForConstant(PyRabb
     PyRabbitizerInstruction *instr;
     int dstOffset = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &instr)) {
         return NULL;
     }
 
@@ -179,7 +181,7 @@ static PyObject *rabbitizer_type_RegistersTracker_processConstant(PyRabbitizerRe
     uint32_t value;
     int instrOffset;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!Ii", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &value, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!Ii", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &value, &instrOffset)) {
         return NULL;
     }
 
@@ -196,7 +198,7 @@ static PyObject *rabbitizer_type_RegistersTracker_getLuiOffsetForLo(PyRabbitizer
     bool dstIsGp = false;
     bool validResults = false;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
         return NULL;
     }
 
@@ -211,11 +213,11 @@ static PyObject *rabbitizer_type_RegistersTracker_preprocessLoAndGetInfo(PyRabbi
     int instrOffset;
     PyRabbitizerLoPairingInfo *ret;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
         return NULL;
     }
 
-    ret = (PyRabbitizerLoPairingInfo*)PyObject_CallObject((PyObject*)&rabbitizer_type_LoPairingInfo_TypeObject, NULL);
+    ret = (PyRabbitizerLoPairingInfo*)PyObject_CallObject(rabbitizer_type_LoPairingInfo_TypeObject, NULL);
     if (ret == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "Internal error: not able to instance LoPairingInfo object");
         return NULL;
@@ -232,7 +234,7 @@ static PyObject *rabbitizer_type_RegistersTracker_processLo(PyRabbitizerRegister
     uint32_t value;
     int instrOffset;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!Ii", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &value, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!Ii", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &value, &instrOffset)) {
         return NULL;
     }
 
@@ -246,7 +248,7 @@ static PyObject *rabbitizer_type_RegistersTracker_processBranch(PyRabbitizerRegi
     PyRabbitizerInstruction *instr;
     int instrOffset;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!i", kwlist, rabbitizer_type_Instruction_TypeObject, &instr, &instrOffset)) {
         return NULL;
     }
 
@@ -259,7 +261,7 @@ static PyObject *rabbitizer_type_RegistersTracker_hasLoButNoHi(PyRabbitizerRegis
     static char *kwlist[] = { "instr", NULL };
     PyRabbitizerInstruction *instr;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, &rabbitizer_type_Instruction_TypeObject, &instr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist, rabbitizer_type_Instruction_TypeObject, &instr)) {
         return NULL;
     }
 
@@ -312,7 +314,7 @@ PyObject *rabbitizer_type_RegistersTracker___getitem__(PyRabbitizerRegistersTrac
         return NULL;
     }
 
-    pyState = (PyRabbitizerTrackedRegisterState *)PyObject_CallObject((PyObject*)&rabbitizer_type_TrackedRegisterState_TypeObject, args);
+    pyState = (PyRabbitizerTrackedRegisterState *)PyObject_CallObject(rabbitizer_type_TrackedRegisterState_TypeObject, args);
     Py_DECREF(args);
     if (pyState == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "Internal error: not able to instance TrackedRegisterState object");
@@ -324,27 +326,28 @@ PyObject *rabbitizer_type_RegistersTracker___getitem__(PyRabbitizerRegistersTrac
 }
 
 
-static PySequenceMethods rabbitizer_type_RegistersTracker_classSeqMethods = {
-	.sq_item = (ssizeargfunc)rabbitizer_type_RegistersTracker___getitem__, // sq_item
-};
-
-
 DEF_RAB_TYPE(RegistersTracker)
 
 
-PyTypeObject rabbitizer_type_RegistersTracker_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.RegistersTracker",
-    .tp_doc = PyDoc_STR("RegistersTracker"),
-    .tp_basicsize = sizeof(PyRabbitizerRegistersTracker),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = PyType_GenericNew,
-    .tp_init = (initproc) rabbitizer_type_RegistersTracker_init,
-    .tp_dealloc = (destructor) rabbitizer_type_RegistersTracker_dealloc,
-    // .tp_repr = (reprfunc) rabbitizer_type_RegistersTracker_repr,
-    .tp_as_sequence = &rabbitizer_type_RegistersTracker_classSeqMethods,
-    // .tp_str = (reprfunc) rabbitizer_type_RegistersTracker_str,
-    .tp_methods = rabbitizer_type_RegistersTracker_methods,
-    // .tp_getset = rabbitizer_type_RegistersTracker_getsetters,
+PyObject *rabbitizer_type_RegistersTracker_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_type_RegistersTracker_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("RegistersTracker")},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_init, rabbitizer_type_RegistersTracker_init},
+    {Py_tp_dealloc, rabbitizer_type_RegistersTracker_dealloc},
+    // {Py_tp_repr, rabbitizer_type_RegistersTracker_repr},
+    {Py_sq_item, rabbitizer_type_RegistersTracker___getitem__},
+    // {Py_tp_str, rabbitizer_type_RegistersTracker_str},
+    {Py_tp_methods, rabbitizer_type_RegistersTracker_methods},
+    // {Py_tp_getset, rabbitizer_type_RegistersTracker_getsetters},
+    {0, NULL},
+};
+
+PyType_Spec rabbitizer_type_RegistersTracker_Spec = {
+    .name = "rabbitizer.RegistersTracker",
+    .basicsize = sizeof(PyRabbitizerRegistersTracker),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = rabbitizer_type_RegistersTracker_Slots,
 };

--- a/rabbitizer/rabbitizer_type_TrackedRegisterState.c
+++ b/rabbitizer/rabbitizer_type_TrackedRegisterState.c
@@ -6,7 +6,9 @@
 
 static void rabbitizer_type_TrackedRegisterState_dealloc(PyRabbitizerTrackedRegisterState *self) {
     RabbitizerTrackedRegisterState_destroy(&self->registerState);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+
+    freefunc tp_free = PyType_GetSlot(Py_TYPE(self), Py_tp_free);
+    tp_free((PyObject *) self);
 }
 
 static int rabbitizer_type_TrackedRegisterState_init(PyRabbitizerTrackedRegisterState *self, PyObject *args, PyObject *kwds) {
@@ -94,18 +96,24 @@ static PyGetSetDef rabbitizer_type_TrackedRegisterState_getsetters[] = {
 DEF_RAB_TYPE(TrackedRegisterState)
 
 
-PyTypeObject rabbitizer_type_TrackedRegisterState_TypeObject = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "rabbitizer.TrackedRegisterState",
-    .tp_doc = PyDoc_STR("TrackedRegisterState"),
-    .tp_basicsize = sizeof(PyRabbitizerTrackedRegisterState),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_new = PyType_GenericNew,
-    .tp_init = (initproc) rabbitizer_type_TrackedRegisterState_init,
-    .tp_dealloc = (destructor) rabbitizer_type_TrackedRegisterState_dealloc,
-    // .tp_repr = (reprfunc) rabbitizer_type_TrackedRegisterState_repr,
-    // .tp_str = (reprfunc) rabbitizer_type_TrackedRegisterState_str,
-    // .tp_methods = rabbitizer_type_TrackedRegisterState_methods,
-    .tp_getset = rabbitizer_type_TrackedRegisterState_getsetters,
+PyObject *rabbitizer_type_TrackedRegisterState_TypeObject = NULL;
+
+static PyType_Slot rabbitizer_type_TrackedRegisterState_Slots[] = {
+    {Py_tp_doc, PyDoc_STR("TrackedRegisterState")},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_init, rabbitizer_type_TrackedRegisterState_init},
+    {Py_tp_dealloc, rabbitizer_type_TrackedRegisterState_dealloc},
+    // {Py_tp_repr, rabbitizer_type_TrackedRegisterState_repr},
+    // {Py_tp_str, rabbitizer_type_TrackedRegisterState_str},
+    // {Py_tp_methods, rabbitizer_type_TrackedRegisterState_methods},
+    {Py_tp_getset, rabbitizer_type_TrackedRegisterState_getsetters},
+    {0, NULL},
+};
+
+PyType_Spec rabbitizer_type_TrackedRegisterState_Spec = {
+    .name = "rabbitizer.TrackedRegisterState",
+    .basicsize = sizeof(PyRabbitizerTrackedRegisterState),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = rabbitizer_type_TrackedRegisterState_Slots,
 };

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
             include_dirs=["include", "rabbitizer", "tables"],
             extra_compile_args = extraCompileArgs,
             depends=headersList,
+            py_limited_api=True,
         ),
     ],
+    options={"bdist_wheel": {"py_limited_api": "cp34"}},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 from setuptools import setup, Extension
+import sysconfig
 from pathlib import Path
 import platform
+
+Py_GIL_DISABLED = sysconfig.get_config_var("Py_GIL_DISABLED")
 
 bindingsPath = Path("rabbitizer")
 srcPath = Path("src")
@@ -20,16 +23,28 @@ if platform.system() == "Linux":
     extraCompileArgs += ["-Werror"]
     extraCompileArgs += ["-Wno-nonnull-compare"]
 
+# Only enable abi3 build if we are not building a free threaded wheel.
+define_macros = []
+py_limited_api = False
+options = {}
+if not Py_GIL_DISABLED:
+    define_macros = [
+        ("Py_LIMITED_API", "0x03040000"),
+    ]
+    py_limited_api = True
+    options={"bdist_wheel": {"py_limited_api": "cp34"}}
+
 setup(
     ext_modules=[
         Extension(
             name="rabbitizer",
             sources=sourcesList,
             include_dirs=["include", "rabbitizer", "tables"],
+            define_macros=define_macros,
             extra_compile_args = extraCompileArgs,
             depends=headersList,
-            py_limited_api=True,
+            py_limited_api=py_limited_api,
         ),
     ],
-    options={"bdist_wheel": {"py_limited_api": "cp34"}},
+    options=options,
 )


### PR DESCRIPTION
Add support for Python's limited API (a.k.a. `abi3`).

This allows us to build a single wheel that can work in multiple Python versions, instead of needing to build a wheel for each Python version.
The minimum Python version for `abi3` compatibility is 3.4 now.
